### PR TITLE
Added option called verbose to throttle addFile

### DIFF
--- a/docs/compress-options.md
+++ b/docs/compress-options.md
@@ -19,3 +19,9 @@ Default: 1
 Sets the level of archive compression.
 
 *Currently, gzip compression related options are not supported due to deficiencies in node's zlib library.*
+
+## verbose
+Type: `Boolean`
+Default: `false`
+
+Sets the level of verbosity when adding files to a zip. (`--verbose` will still print)

--- a/tasks/compress.js
+++ b/tasks/compress.js
@@ -118,7 +118,9 @@ module.exports = function(grunt) {
           internalFileName = (isExpandedPair) ? filePair.dest : unixifyPath(path.join(filePair.dest || '', srcFile));
 
           archive.addFile(fs.createReadStream(srcFile), { name: internalFileName }, function(err) {
-            grunt.log.writeln('Archiving ' + srcFile.cyan + ' -> ' + archiveFile.cyan + '/'.cyan + internalFileName.cyan);
+            var logger = (options.verbose) ? grunt.log : grunt.verbose;
+
+            logger.writeln('Archiving ' + srcFile.cyan + ' -> ' + archiveFile.cyan + '/'.cyan + internalFileName.cyan);
             nextFile(err);
           });
         }, nextPair);


### PR DESCRIPTION
This is a patch for Issue #19.

Basically it adds a `verbose` config (defaulting to false) to skip the logging of adding a file to the archive. If `verbose` is in the options or `--verbose` is used on the CLI then it will log the action.
