### PR TITLE
Added pretty size printing option

### DIFF
--- a/docs/compress-options.md
+++ b/docs/compress-options.md
@@ -19,3 +19,9 @@ Default: 1
 Sets the level of archive compression.
 
 *Currently, gzip compression related options are not supported due to deficiencies in node's zlib library.*
+
+## pretty
+Type: `Boolean`
+Default: `false`
+
+Pretty print file sizes when logging.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "dependencies": {
     "archiver": "~0.3.0",
     "rimraf": "~2.0.2",
-    "grunt-lib-contrib": "~0.5.1"
+    "grunt-lib-contrib": "~0.5.1",
+    "prettysize": "~0.0.2"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.1.1",

--- a/tasks/compress.js
+++ b/tasks/compress.js
@@ -12,6 +12,7 @@ module.exports = function(grunt) {
   var fs = require('fs');
   var path = require('path');
   var rimraf = require('rimraf');
+  var prettySize = require('prettysize');
 
   grunt.registerMultiTask('compress', 'Compress files.', function() {
     var archiver = require('archiver');
@@ -27,6 +28,13 @@ module.exports = function(grunt) {
       mode: null,
       level: 1
     });
+
+    var pretty = function(size) {
+        if (!options.pretty) {
+          return size + ' bytes';
+        }
+        return prettySize(size);
+    };
 
     var archiverOptions = options;
 
@@ -89,7 +97,7 @@ module.exports = function(grunt) {
       srcStream.pipe(zlib.createGzip()).pipe(archiveStream);
 
       archiveStream.on('close', function() {
-        grunt.log.writeln('File ' + archiveFile.cyan + ' created (' + getSize(archiveFile) + ' bytes).');
+        grunt.log.writeln('File ' + archiveFile.cyan + ' created (' + pretty(getSize(archiveFile)) + ').');
         done();
       });
     } else if (mode === 'tar' || mode === 'zip') {
@@ -129,9 +137,9 @@ module.exports = function(grunt) {
 
         archive.finalize(function(err, written) {
           if (shouldGzipTar) {
-            grunt.log.writeln('Created ' + archiveFile.cyan + ' (' + getSize(archiveFile) + ' bytes)');
+            grunt.log.writeln('Created ' + archiveFile.cyan + ' (' + pretty(getSize(archiveFile)) + ')');
           } else {
-            grunt.log.writeln('Created ' + archiveFile.cyan + ' (' + written + ' bytes)');
+            grunt.log.writeln('Created ' + archiveFile.cyan + ' (' + pretty(written) + ')');
           }
 
           done(err);


### PR DESCRIPTION
This is a simple enhancement to allow pretty printing (2.5 MB, 17.2 MB, etc) of the compressed file instead of just printing bytes. It defaults to `false` so it won't change things under the hood.
