### PR TITLE
Zip task produces invalid archive when run alone

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -66,7 +66,8 @@ module.exports = function(grunt) {
 
     // Unit tests.
     nodeunit: {
-      tests: ['test/*_test.js']
+      tests: ['test/*_test.js'],
+      zip: ['test/compress_zip_test.js']
     }
   });
 
@@ -86,4 +87,6 @@ module.exports = function(grunt) {
   // By default, lint and run all tests.
   grunt.registerTask('default', ['jshint', 'test', 'build-contrib']);
 
+  // Demonstrating that zip task fails when another compress task isn't run after it
+  grunt.registerTask('test_zip', ['clean', 'compress:zip', 'nodeunit:zip']);
 };

--- a/test/compress_zip_test.js
+++ b/test/compress_zip_test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var grunt = require('grunt');
+var path = require('path');
+var zlib = require('zlib');
+var fs = require('fs');
+var unzip = require('unzip');
+var tar = require('tar');
+var compress = require('../tasks/lib/compress')(grunt);
+
+exports.compress_zip = {
+  zip: function(test) {
+    test.expect(1);
+    var expected = [
+      'folder_one/one.css', 'folder_one/one.js',
+      'folder_two/two.css', 'folder_two/two.js',
+      'test.css', 'test.js',
+    ];
+    var actual = [];
+    var parse = unzip.Parse();
+    fs.createReadStream(path.join('tmp', 'compress_test_files.zip')).pipe(parse);
+    parse.on('entry', function(entry) {
+      actual.push(entry.path);
+    });
+    parse.on('close', function() {
+      test.deepEqual(actual, expected, 'zip file should unzip and contain all of the expected files');
+      test.done();
+    });
+  },
+};


### PR DESCRIPTION
Added a task and test to demonstrate that the zip task 'fails' (it produces an invalid archive) when another compress task isn't run after it.
