### PR TITLE
Adding war and jar file extensions to autodetect mode (zip)

### DIFF
--- a/tasks/lib/compress.js
+++ b/tasks/lib/compress.js
@@ -177,6 +177,12 @@ module.exports = function(grunt) {
     if (grunt.util._.endsWith(dest, '.tar.gz')) {
       return 'tgz';
     }
+    if (grunt.util._.endsWith(dest, '.war')) {
+      return 'zip';
+    }
+    if (grunt.util._.endsWith(dest, '.jar')) {
+      return 'zip';
+    }
     var ext = path.extname(dest).replace('.', '');
     if (ext === 'gz') {
       return 'gzip';


### PR DESCRIPTION
Could you add .war and .jar into autodetect for zip mode? One of the plugins I'm using is taking in a war file, and it would be nice to have it autodetect to zip
