### PR TITLE
catch archiver error and feed it back to reuse error handler.

### DIFF
--- a/tasks/lib/compress.js
+++ b/tasks/lib/compress.js
@@ -137,6 +137,11 @@ module.exports = function(grunt) {
         var internalFileName = (isExpandedPair) ? file.dest : exports.unixifyPath(path.join(file.dest || '', srcFile));
 
         archive.file(srcFile, { name: internalFileName }, function(err) {
+          if (err) {
+            archive.emit('error', err);
+            return;
+          }
+
           grunt.verbose.writeln('Archiving ' + srcFile.cyan + ' -> ' + String(dest).cyan + '/'.cyan + internalFileName.cyan);
         });
       });


### PR DESCRIPTION
As @tescherm pointed out in #80, due to the way errors are handled with callbacks, errors would slip by without being reported. im going to research going all events in archiver v0.6 because i hate all the checking of callbacks anyways. i think an `entry` event giving back file info would be a good compromise.

cc @shama
