### PR TITLE
Fix ignored 'cwd' when looking up files to zip.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,6 +39,16 @@ module.exports = function(grunt) {
           {expand: true, cwd: 'test/fixtures/', src: ['**/*']}
         ]
       },
+      zipCwd: {
+        options: {
+          archive: function () {
+            return 'tmp/compress_test_files_cwd.zip';
+          }
+        },
+        files: [
+          {expand: true, cwd: 'test/fixtures/folder_one/', src: ['**/*'], dest: ''}
+        ]
+      },
       tar: {
         options: {
           archive: 'tmp/compress_test_files.tar'

--- a/tasks/lib/compress.js
+++ b/tasks/lib/compress.js
@@ -134,17 +134,20 @@ module.exports = function(grunt) {
     files.forEach(function(file) {
       var isExpandedPair = file.orig.expand || false;
       var src = file.src.filter(function(f) {
-        return grunt.file.isFile(f);
+        var cwdFile = path.join(file.cwd || '', f);
+        return grunt.file.isFile(cwdFile);
       });
 
       src.forEach(function(srcFile) {
+        var cwdFile = path.join(file.cwd || '', srcFile);
         var internalFileName = (isExpandedPair) ? file.dest : exports.unixifyPath(path.join(file.dest || '', srcFile));
+		  
         var fileData = {
           name: internalFileName,
-          _srcFile: srcFile
+          _srcFile: cwdFile
         };
 
-        archive.file(srcFile, fileData);
+        archive.file(cwdFile, fileData);
       });
     });
 

--- a/test/compress_test.js
+++ b/test/compress_test.js
@@ -27,6 +27,22 @@ exports.compress = {
       test.done();
     });
   },
+  zipCwd: function(test) {
+    test.expect(1);
+    var expected = [
+      'one.css', 'one.js',
+    ];
+    var actual = [];
+    var parse = unzip.Parse();
+    fs.createReadStream(path.join('tmp', 'compress_test_files_cwd.zip')).pipe(parse);
+    parse.on('entry', function(entry) {
+      actual.push(entry.path);
+    });
+    parse.on('close', function() {
+      test.deepEqual(actual, expected, 'zip file should unzip and contain all of the expected files');
+      test.done();
+    });
+  },
   tar: function(test) {
     test.expect(1);
     var expected = [


### PR DESCRIPTION
Problem: Zipping a specific subfolder using 'cwd' in the options was not zipping the correct files.
Added one test to test zipping only a subfolder using the 'cwd' parameter.
