### PR TITLE
support of mode parameter

### DIFF
--- a/tasks/lib/compress.js
+++ b/tasks/lib/compress.js
@@ -143,6 +143,9 @@ module.exports = function(grunt) {
           name: internalFileName,
           _srcFile: srcFile
         };
+        if ('mode' in file) {
+            fileData.mode = file.mode;
+        }
 
         archive.file(srcFile, fileData);
       });


### PR DESCRIPTION
Optional parameter to set access permissions for archived files, e.g.:

```
files: [
    {
        src: ['*.sh'],
        mode: 484 /*0744*/,
        expand: true
    }
]
```
