### PR TITLE
pass file mode into the archiver

### DIFF
--- a/tasks/lib/compress.js
+++ b/tasks/lib/compress.js
@@ -129,6 +129,10 @@ module.exports = function(grunt) {
         };
 
         if (grunt.file.isFile(srcFile)) {
+          var stat = fs.statSync(srcFile);
+          if (stat && stat.mode) {
+            fileData.mode = stat.mode;
+          }
           archive.file(srcFile, fileData);
         } else if (grunt.file.isDir(srcFile)) {
           fileData.type = 'directory';


### PR DESCRIPTION
fixed #109, take the file mode into consideration to avoid using default one.
