### PR TITLE
Add a path to warn message when type is invalid

### DIFF
--- a/tasks/lib/compress.js
+++ b/tasks/lib/compress.js
@@ -126,7 +126,7 @@ module.exports = function(grunt) {
           fileData.sourcePath = srcFile;
           archive.append(null, fileData);
         } else {
-          grunt.fail.warn('srcFile should be a valid file or directory');
+          grunt.fail.warn('srcFile (' + srcFile + ') should be a valid file or directory');
         }
       });
     });


### PR DESCRIPTION
When you have thousands of files to compress and it fails with `srcFile should be a valid file or directory`, go try to figure which one and why. This changeset gives a relief to end user by at least pointing to file (path) as a start point for further investigation.
