### PR TITLE
Prevent zipping dot files

### DIFF
--- a/tasks/lib/compress.js
+++ b/tasks/lib/compress.js
@@ -138,8 +138,9 @@ module.exports = function(grunt) {
         var internalFileName = (isExpandedPair) ? file.dest : exports.unixifyPath(path.join(file.dest || '', srcFile));
 
         // check if internal file name is not a dot, should not be present in an archive
-        if (internalFileName === '.')
+        if (internalFileName === '.') {
           return;
+        }
 
         if (fstat.isDirectory() && internalFileName.slice(-1) !== '/') {
           srcFile += '/';


### PR DESCRIPTION
When I have the following target for compress:

```
    gnap: {
        options: {
            archive: './releases/GNaP.Themes.Web.GNaP/gnap.zip',
            mode: 'zip'
        },
        files: [{ expand: true, cwd: './deploy/', src: ['**'] }]
    }
```

I end up with a zip file called gnap.zip, as intended. However, when looking inside the zip, at the root we see a file called "." being part of the zip. I suspect this is due the expand from the files, expanding everything, including "." as the base.

I added an if statement to exclude "." files from the archive. Another solution might be to have some sort of exclude list option?
