### PR TITLE
Add BZip2 compression support

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "archiver": "~0.11.0",
     "chalk": "^0.5.1",
-    "prettysize": "~0.0.2"
+    "prettysize": "~0.0.2",
+    "compressjs": "~1.0.2"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.10.0",

--- a/tasks/compress.js
+++ b/tasks/compress.js
@@ -24,11 +24,11 @@ module.exports = function(grunt) {
 
     compress.options.mode = compress.options.mode || compress.autoDetectMode(compress.options.archive);
 
-    if (grunt.util._.include(['zip', 'tar', 'tgz', 'gzip', 'deflate', 'deflateRaw'], compress.options.mode) === false) {
+    if (grunt.util._.include(['zip', 'tar', 'tgz', 'gzip', 'bz2', 'deflate', 'deflateRaw'], compress.options.mode) === false) {
       grunt.fail.warn('Mode ' + String(compress.options.mode).cyan + ' not supported.');
     }
 
-    if (compress.options.mode === 'gzip' || compress.options.mode.slice(0, 7) === 'deflate') {
+    if (compress.options.mode === 'gzip' || compress.options.mode.slice(0, 7) === 'deflate' || compress.options.mode === 'bz2') {
       compress[compress.options.mode](this.files, this.async());
     } else {
       compress.tar(this.files, this.async());


### PR DESCRIPTION
Using `compressjs` package, we can now compress files with BZip2 algorithm.