### PR TITLE
reduce stat calls by passing through to archiver.

### DIFF
--- a/tasks/lib/compress.js
+++ b/tasks/lib/compress.js
@@ -150,7 +150,8 @@ module.exports = function(grunt) {
         }
 
         var fileData = {
-          name: internalFileName
+          name: internalFileName,
+          stats: fstat
         };
 
         for (var i = 0; i < dataWhitelist.length; i++) {


### PR DESCRIPTION
reduces number of fstat calls (by up to 50%) used by this task and archiver

cc @vladikoff 