### PR TITLE
Made grunt to log each file only on verbose

### DIFF
--- a/tasks/lib/compress.js
+++ b/tasks/lib/compress.js
@@ -34,16 +34,22 @@ module.exports = function(grunt) {
   // 1 to 1 gziping of files
   exports.gzip = function(files, done) {
     exports.singleFile(files, zlib.createGzip, 'gz', done);
+    grunt.log.writeln('Compressed ' + chalk.cyan(files.length)
+      + grunt.util.pluralize(files.length, ' file/ files'));
   };
 
   // 1 to 1 deflate of files
   exports.deflate = function(files, done) {
     exports.singleFile(files, zlib.createDeflate, 'deflate', done);
+    grunt.log.writeln('Compressed ' + chalk.cyan(files.length)
+      + grunt.util.pluralize(files.length, ' file/ files'));
   };
 
   // 1 to 1 deflateRaw of files
   exports.deflateRaw = function(files, done) {
     exports.singleFile(files, zlib.createDeflateRaw, 'deflate', done);
+    grunt.log.writeln('Compressed ' + chalk.cyan(files.length)
+      + grunt.util.pluralize(files.length, ' file/ files'));
   };
 
   // 1 to 1 compression of files, expects a compatible zlib method to be passed in, see above
@@ -124,7 +130,7 @@ module.exports = function(grunt) {
 
     destStream.on('close', function() {
       var size = archive.pointer();
-      grunt.log.writeln('Created ' + chalk.cyan(dest) + ' (' + exports.getSize(size) + ')');
+      grunt.verbose.writeln('Created ' + chalk.cyan(dest) + ' (' + exports.getSize(size) + ')');
       done();
     });
 
@@ -183,6 +189,8 @@ module.exports = function(grunt) {
       });
     });
 
+    grunt.log.writeln('Compressed ' + chalk.cyan(files.length)
+      + grunt.util.pluralize(files.length, ' file/ files'));
     archive.finalize();
   };
 


### PR DESCRIPTION
@vladikoff please take a look at this change. I am working on a project that outputs only for this task about __3600__ lines of log in travis and is hard to follow the log. And also this PR fixes this issue https://github.com/gruntjs/grunt-contrib-compress/issues/161