### PR TITLE
Add Brotli comperssion algorithm support (via iltorb)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,11 @@ node_js:
   - '5'
   - '4'
   - '0.10'
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -73,6 +73,15 @@ module.exports = function(grunt) {
           mode: 'gzip'
         }
       },
+      br: {
+        expand: true,
+        cwd: 'test/fixtures/',
+        src: ['**/*.{css,html,js}'],
+        dest: 'tmp/br/',
+        options: {
+          mode: 'br'
+        }
+      },
       deflate: {
         expand: true,
         cwd: 'test/fixtures/',

--- a/README.md
+++ b/README.md
@@ -28,35 +28,37 @@ _Run this task with the `grunt compress` command._
 Task targets, files and options may be specified according to the grunt [Configuring tasks](http://gruntjs.com/configuring-tasks) guide.
 
 Node Libraries Used:
-[archiver](https://github.com/ctalkington/node-archiver) (for zip/tar)
-[zlib](http://nodejs.org/api/zlib.html#zlib_options) (for gzip).
+* [archiver](https://github.com/ctalkington/node-archiver) (for zip/tar)
+* [zlib](http://nodejs.org/api/zlib.html#zlib_options) (for gzip)
+* [iltorb](https://github.com/MayhemYDG/iltorb) (for Brotli)
+
 ### Options
 
 #### archive
-Type: `String` or `Function`  
+Type: `String` or `Function`
 Modes: `zip` `tar`
 
 This is used to define where to output the archive. Each target can only have one output file.
 If the type is a Function it must return a String.
 
-*This option is only appropriate for many-files-to-one compression modes like zip and tar.  For gzip for example, please use grunt's standard src/dest specifications.*
+*This option is only appropriate for many-files-to-one compression modes like zip and tar. For gzip and brotli for example, please use grunt's standard src/dest specifications.*
 
 #### mode
 Type: `String`
 
-This is used to define which mode to use, currently supports `gzip`, `deflate`, `deflateRaw`, `tar`, `tgz` (tar gzip) and `zip`.
+Determines the mode to use: `gzip`, `deflate`, `deflateRaw`, `tar`, `tgz` (tar gzip), `zip` and `br` (Brotli).
 
 Automatically detected per `dest:src` pair, but can be overridden per target if desired.
 
 #### level
-Type: `Integer`  
-Modes: `zip` `gzip`  
+Type: `Integer`
+Modes: `zip` `gzip`
 Default: `1`
 
 Sets the level of archive compression.
 
 #### pretty
-Type: `Boolean`  
+Type: `Boolean`
 Default: `false`
 
 Pretty print file sizes when logging.
@@ -67,25 +69,25 @@ The following additonal keys may be passed as part of a dest:src pair when using
 All keys can be defined as a `Function` that receives the file name and returns in the type specified below.
 
 #### date
-Type: `Date`  
+Type: `Date`
 Modes: `zip` `tar` `tgz`
 
 Sets the file date.
 
 #### mode
-Type: `Integer`  
+Type: `Integer`
 Modes: `zip` `tar` `tgz`
 
 Sets the file permissions.
 
 #### store
-Type: `Boolean`  
+Type: `Boolean`
 Default: `false`
 
 If true, file contents will be archived without compression.
 
 #### comment
-Type: `String`  
+Type: `String`
 Modes: `zip`
 
 Sets the file comment.
@@ -115,6 +117,21 @@ compress: {
   main: {
     options: {
       mode: 'gzip'
+    },
+    expand: true,
+    cwd: 'assets/',
+    src: ['**/*'],
+    dest: 'public/'
+  }
+}
+```
+
+```js
+// compress assets using brotli 1-to-1 for production
+compress: {
+  main: {
+    options: {
+      mode: 'br'
     },
     expand: true,
     cwd: 'assets/',

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "archiver": "^0.16.0",
     "chalk": "^1.0.0",
+    "iltorb": "^1.0.7",
     "pretty-bytes": "^2.0.1"
   },
   "devDependencies": {

--- a/tasks/compress.js
+++ b/tasks/compress.js
@@ -24,11 +24,11 @@ module.exports = function(grunt) {
 
     compress.options.mode = compress.options.mode || compress.autoDetectMode(compress.options.archive);
 
-    if (grunt.util._.include(['zip', 'tar', 'tgz', 'gzip', 'deflate', 'deflateRaw'], compress.options.mode) === false) {
+    if (grunt.util._.include(['zip', 'tar', 'tgz', 'gzip', 'deflate', 'deflateRaw', 'br'], compress.options.mode) === false) {
       grunt.fail.warn('Mode ' + String(compress.options.mode).cyan + ' not supported.');
     }
 
-    if (compress.options.mode === 'gzip' || compress.options.mode.slice(0, 7) === 'deflate') {
+    if (compress.options.mode === 'gzip' || compress.options.mode === 'br' || compress.options.mode.slice(0, 7) === 'deflate') {
       compress[compress.options.mode](this.files, this.async());
     } else {
       compress.tar(this.files, this.async());

--- a/tasks/lib/compress.js
+++ b/tasks/lib/compress.js
@@ -14,6 +14,7 @@ var prettyBytes = require('pretty-bytes');
 var chalk = require('chalk');
 var zlib = require('zlib');
 var archiver = require('archiver');
+var iltorb = require('iltorb');
 
 module.exports = function(grunt) {
 
@@ -48,6 +49,13 @@ module.exports = function(grunt) {
   // 1 to 1 deflateRaw of files
   exports.deflateRaw = function(files, done) {
     exports.singleFile(files, zlib.createDeflateRaw, 'deflate', done);
+    grunt.log.ok('Compressed ' + chalk.cyan(files.length) + ' '
+      + grunt.util.pluralize(files.length, 'file/files.'));
+  };
+
+  // 1 to 1 brotling of files
+  exports.br = function(files, done) {
+    exports.singleFile(files, iltorb.compressStream, 'br', done);
     grunt.log.ok('Compressed ' + chalk.cyan(files.length) + ' '
       + grunt.util.pluralize(files.length, 'file/files.'));
   };

--- a/test/compress_test.js
+++ b/test/compress_test.js
@@ -6,6 +6,7 @@ var zlib = require('zlib');
 var fs = require('fs');
 var unzip = require('unzip');
 var tar = require('tar');
+var iltorb = require('iltorb');
 
 exports.compress = {
   zip: function(test) {
@@ -86,6 +87,26 @@ exports.compress = {
         })
         .on('end', function() {
           test.equal(actual, expected, 'should be equal to fixture after gunzipping');
+          next();
+        });
+    }, test.done);
+  },
+  br: function(test) {
+    test.expect(3);
+    grunt.util.async.forEachSeries([
+      'test.js',
+      path.join('folder_one', 'one.css'),
+      path.join('folder_two', 'two.js')
+    ], function(file, next) {
+      var expected = grunt.file.read(path.join('test', 'fixtures', file));
+      var actual = '';
+      fs.createReadStream(path.join('tmp', 'br', file))
+        .pipe(iltorb.decompressStream())
+        .on('data', function(buf) {
+          actual += buf.toString();
+        })
+        .on('end', function() {
+          test.equal(actual, expected, 'should be equal to fixture after unbrotling');
           next();
         });
     }, test.done);


### PR DESCRIPTION
[Brotli](https://github.com/google/brotli) is a new generic-purpose lossless compression algorithm by Google which is similar in speed to gzip/deflate but has a significantly better compression ratio (17-25% for web assets). It is used in the WOFF2 web font format and that browser code is now being exposed as a method for HTTP content compression over HTTPS using `Content-Encoding: br`/`Accept-Encoding: br`.

It is already usable in:
* **Mozilla Firefox 44** ([release notes](https://developer.mozilla.org/en-US/Firefox/Releases/44#HTTP); issues [#366559](https://bugzilla.mozilla.org/show_bug.cgi?id=366559) & [#1211916](https://bugzilla.mozilla.org/show_bug.cgi?id=1211916))
* **Google Chrome Canary** ([Intent to Ship](https://groups.google.com/a/chromium.org/forum/#!searchin/blink-dev/brotli/blink-dev/JufzX024oy0/WEOGbN43AwAJ--); issue [#452335](https://code.google.com/p/chromium/issues/detail?id=452335))
* **nginx** using the [ngx_brotli](https://github.com/google/ngx_brotli) modules that can serve pre-compressed files and compress responses on-the-fly
* **Apache** for pre-compressed files ([read this how-to](https://lyncd.com/2015/11/brotli-support-apache/))
* **gulp** using the [gulp-brotli](https://github.com/mayhemydg/gulp-brotli) module