### PR TITLE
list each file archived only with verbose flag

### DIFF
--- a/tasks/lib/compress.js
+++ b/tasks/lib/compress.js
@@ -76,7 +76,7 @@ module.exports = function(grunt) {
             var compressedSize = exports.getSize(filePair.dest);
             var ratio = Math.round(parseInt(compressedSize) / parseInt(originalSize) * 100) + '%';
 
-            grunt.log.writeln('Created ' + chalk.cyan(filePair.dest) + ' (' + compressedSize + ') - ' + chalk.cyan(ratio) + ' of the original size');
+            grunt.verbose.writeln('Created ' + chalk.cyan(filePair.dest) + ' (' + compressedSize + ') - ' + chalk.cyan(ratio) + ' of the original size');
             nextFile();
           });
         }


### PR DESCRIPTION
Before: 
![screen shot 2016-03-08 at 13 41 02](https://cloud.githubusercontent.com/assets/8288804/13600723/7e1a51b6-e533-11e5-8fc1-9e46212b2e42.png)

After:
![screen shot 2016-03-08 at 13 41 17](https://cloud.githubusercontent.com/assets/8288804/13600724/7e357d24-e533-11e5-8ef8-5cd8ad72e06d.png)

Now each archived file will be logged only when the verbose flag will be passed. This problem was fixed in the past but in the newer 1.x reappeared. CI console gets really polluted when you archive 3000+ files
