### PR TITLE
Added option to not to create empty archive

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,22 +59,9 @@ module.exports = function(grunt) {
           {expand: true, cwd: 'test/fixtures/', src: ['**'], dest: './'}
         ]
       },
-      zipDoNotCreateEmptyArchiveTrue: {
+      zipCreateEmptyArchiveTrue: {
         options: {
-          doNotCreateEmptyArchive: true,
-          archive: function () {
-            return 'tmp/zip_should_not_be_created_1.zip';
-          }
-        },
-        files: [{
-          expand: true,
-          cwd: 'test/fixtures/',
-          src: ['NotExistingFilePath.js']
-        }]
-      },
-      zipDoNotCreateEmptyArchiveFalse: {
-        options: {
-          doNotCreateEmptyArchive: false,
+          createEmptyArchive: true,
           archive: function () {
             return 'tmp/zip_must_be_created_1.zip';
           }
@@ -85,10 +72,23 @@ module.exports = function(grunt) {
           src: ['NotExistingFilePath.js']
         }]
       },
-      zipNoDoNotCreateEmptyArchiveOption: {
+      zipCreateEmptyArchiveFalse: {
+        options: {
+          createEmptyArchive: false,
+          archive: function () {
+            return 'tmp/zip_should_not_be_created.zip';
+          }
+        },
+        files: [{
+          expand: true,
+          cwd: 'test/fixtures/',
+          src: ['NotExistingFilePath.js']
+        }]
+      },
+      zipNoCreateEmptyArchiveOption: {
         options: {
           archive: function () {
-            return 'tmp/zip_must_be_created_2.zip';
+            return 'tmp/zip_must_be_created_1.zip';
           }
         },
         files: [{

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,7 +63,7 @@ module.exports = function(grunt) {
         options: {
           doNotCreateEmptyArchive: true,
           archive: function () {
-            return 'tmp/compress_test_files_empty_must_not_be_created_because_option_set_to_true.zip';
+            return 'tmp/zip_should_not_be_created_1.zip';
           }
         },
         files: [
@@ -74,7 +74,7 @@ module.exports = function(grunt) {
         options: {
           doNotCreateEmptyArchive: false,
           archive: function () {
-            return 'tmp/compress_test_files_empty_must_be_created_because_option_set_to_false.zip';
+            return 'tmp/zip_must_be_created_1.zip';
           }
         },
         files: [
@@ -84,7 +84,7 @@ module.exports = function(grunt) {
       zipNoDoNotCreateEmptyArchiveOption: {
         options: {
           archive: function () {
-            return 'tmp/compress_test_files_empty_must_be_created_because_no_option_passed.zip';
+            return 'tmp/zip_must_be_created_2.zip';
           }
         },
         files: [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -88,7 +88,7 @@ module.exports = function(grunt) {
       zipNoCreateEmptyArchiveOption: {
         options: {
           archive: function () {
-            return 'tmp/zip_must_be_created_1.zip';
+            return 'tmp/zip_must_be_created_2.zip';
           }
         },
         files: [{

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -82,7 +82,7 @@ module.exports = function(grunt) {
         files: [{
           expand: true,
           cwd: 'test/fixtures/',
-          src: ['NotExistingFilePath.js']
+          src: ['NotExistentFilePath.js']
         }]
       },
       zipCreateEmptyArchiveFalse: {
@@ -95,7 +95,7 @@ module.exports = function(grunt) {
         files: [{
           expand: true,
           cwd: 'test/fixtures/',
-          src: ['NotExistingFilePath.js']
+          src: ['NotExistentFilePath.js']
         }]
       },
       zipNoCreateEmptyArchiveOption: {
@@ -107,7 +107,7 @@ module.exports = function(grunt) {
         files: [{
           expand: true,
           cwd: 'test/fixtures/',
-          src: ['NotExistingFilePath.js']
+          src: ['NotExistentFilePath.js']
         }]
       },
       tar: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,6 +59,38 @@ module.exports = function(grunt) {
           {expand: true, cwd: 'test/fixtures/', src: ['**'], dest: './'}
         ]
       },
+      zipDoNotCreateEmptyArchiveTrue: {
+        options: {
+          doNotCreateEmptyArchive: true,
+          archive: function () {
+            return 'tmp/compress_test_files_empty_must_not_be_created_because_option_set_to_true.zip';
+          }
+        },
+        files: [
+          {expand: true, cwd: 'test/fixtures/', src: ['NotExistingFilePath.js']}
+        ]
+      },
+      zipDoNotCreateEmptyArchiveFalse: {
+        options: {
+          doNotCreateEmptyArchive: false,
+          archive: function () {
+            return 'tmp/compress_test_files_empty_must_be_created_because_option_set_to_false.zip';
+          }
+        },
+        files: [
+          {expand: true, cwd: 'test/fixtures/', src: ['NotExistingFilePath.js']}
+        ]
+      },
+      zipNoDoNotCreateEmptyArchiveOption: {
+        options: {
+          archive: function () {
+            return 'tmp/compress_test_files_empty_must_be_created_because_no_option_passed.zip';
+          }
+        },
+        files: [
+          {expand: true, cwd: 'test/fixtures/', src: ['NotExistingFilePath.js']}
+        ]
+      },
       tar: {
         options: {
           archive: 'tmp/compress_test_files.tar'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -66,9 +66,11 @@ module.exports = function(grunt) {
             return 'tmp/zip_should_not_be_created_1.zip';
           }
         },
-        files: [
-          {expand: true, cwd: 'test/fixtures/', src: ['NotExistingFilePath.js']}
-        ]
+        files: [{
+          expand: true,
+          cwd: 'test/fixtures/',
+          src: ['NotExistingFilePath.js']
+        }]
       },
       zipDoNotCreateEmptyArchiveFalse: {
         options: {
@@ -77,9 +79,11 @@ module.exports = function(grunt) {
             return 'tmp/zip_must_be_created_1.zip';
           }
         },
-        files: [
-          {expand: true, cwd: 'test/fixtures/', src: ['NotExistingFilePath.js']}
-        ]
+        files: [{
+          expand: true,
+          cwd: 'test/fixtures/',
+          src: ['NotExistingFilePath.js']
+        }]
       },
       zipNoDoNotCreateEmptyArchiveOption: {
         options: {
@@ -87,9 +91,11 @@ module.exports = function(grunt) {
             return 'tmp/zip_must_be_created_2.zip';
           }
         },
-        files: [
-          {expand: true, cwd: 'test/fixtures/', src: ['NotExistingFilePath.js']}
-        ]
+        files: [{
+          expand: true,
+          cwd: 'test/fixtures/',
+          src: ['NotExistingFilePath.js']
+        }]
       },
       tar: {
         options: {

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Default: `false`
 
 Pretty print file sizes when logging.
 
-#### doNotCreateEmptyArchive
+#### createEmptyArchive
 Type: `Boolean`
-Default: `false`
+Default: `true`
 
 This can be used when you don't want to get an empty archive as a result, if there are no files at the specified paths.
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ Default: `false`
 
 Pretty print file sizes when logging.
 
+#### doNotCreateEmptyArchive
+Type: `Boolean`
+Default: `false`
+
+This is used when you don't want to get empty archive as a result, when there are no files at specified paths.
+
+It may be usefull, if you don't clearly know if files are exists and you don't need empty archive as a result.
+
 ### File Data
 
 The following additional keys may be passed as part of a dest:src pair when using an Archiver-backed format.

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ Pretty print file sizes when logging.
 Type: `Boolean`
 Default: `false`
 
-This is used when you don't want to get empty archive as a result, when there are no files at specified paths.
+This can be used when you don't want to get an empty archive as a result, if there are no files at the specified paths.
 
-It may be usefull, if you don't clearly know if files are exists and you don't need empty archive as a result.
+It may be useful, if you don't clearly know if files exist and you don't need an empty archive as a result.
 
 ### File Data
 

--- a/README.md
+++ b/README.md
@@ -101,14 +101,6 @@ Default: `false`
 
 Pretty print file sizes when logging.
 
-#### createEmptyArchive
-Type: `Boolean`  
-Default: `true`
-
-This can be used when you don't want to get an empty archive as a result, if there are no files at the specified paths.
-
-It may be useful, if you don't clearly know if files exist and you don't need an empty archive as a result.
-
 ### File Data
 
 The following additional keys may be passed as part of a `dest:src` pair when using an Archiver-backed format.

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Default: `false`
 
 Pretty print file sizes when logging.
 
-#### createEmptyArchived
-Type: `Boolean`
+#### createEmptyArchive
+Type: `Boolean`  
 Default: `true`
 
 This can be used when you don't want to get an empty archive as a result, if there are no files at the specified paths.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Default: `false`
 
 Pretty print file sizes when logging.
 
-#### createEmptyArchive
+#### createEmptyArchived
 Type: `Boolean`
 Default: `true`
 

--- a/docs/compress-options.md
+++ b/docs/compress-options.md
@@ -69,6 +69,14 @@ Default: `false`
 
 Pretty print file sizes when logging.
 
+#### createEmptyArchive
+Type: `Boolean`
+Default: `true`
+
+This can be used when you don't want to get an empty archive as a result, if there are no files at the specified paths.
+
+It may be useful, if you don't clearly know if files exist and you don't need an empty archive as a result.
+
 # File Data
 
 The following additional keys may be passed as part of a `dest:src` pair when using an Archiver-backed format.

--- a/docs/compress-options.md
+++ b/docs/compress-options.md
@@ -69,7 +69,7 @@ Default: `false`
 
 Pretty print file sizes when logging.
 
-#### createEmptyArchive
+## createEmptyArchive
 Type: `Boolean`
 Default: `true`
 

--- a/tasks/compress.js
+++ b/tasks/compress.js
@@ -21,7 +21,7 @@ module.exports = function(grunt) {
     });
 
     if (compress.options.doNotCreateEmptyArchive && this.files.length === 0) {
-      grunt.log.ok('No files found. Archive wouldn\'t be created ("doNotCreateEmptyArchive" option is set to true)');
+      grunt.log.ok('No files found. Archive won\'t be created ("doNotCreateEmptyArchive" option is set to true)');
       return;
     }
 

--- a/tasks/compress.js
+++ b/tasks/compress.js
@@ -16,8 +16,14 @@ module.exports = function(grunt) {
     compress.options = this.options({
       archive: null,
       mode: null,
+      doNotCreateEmptyArchive: false,
       level: 1
     });
+
+    if (compress.options.doNotCreateEmptyArchive && this.files.length === 0) {
+      grunt.log.ok('No files found. Archive wouldn\'t be created ("doNotCreateEmptyArchive" is set to true)');
+      return;
+    }
 
     if (typeof compress.options.archive === 'function') {
       compress.options.archive = compress.options.archive();

--- a/tasks/compress.js
+++ b/tasks/compress.js
@@ -16,12 +16,12 @@ module.exports = function(grunt) {
     compress.options = this.options({
       archive: null,
       mode: null,
-      doNotCreateEmptyArchive: false,
+      createEmptyArchive: true,
       level: 1
     });
 
-    if (compress.options.doNotCreateEmptyArchive && this.files.length === 0) {
-      grunt.log.ok('No files found. Archive won\'t be created ("doNotCreateEmptyArchive" option is set to true)');
+    if (compress.options.createEmptyArchive === false && this.files.length === 0) {
+      grunt.log.ok('No files found. Archive won\'t be created ("createEmptyArchive" option is set to true)');
       return;
     }
 

--- a/tasks/compress.js
+++ b/tasks/compress.js
@@ -21,7 +21,7 @@ module.exports = function(grunt) {
     });
 
     if (compress.options.doNotCreateEmptyArchive && this.files.length === 0) {
-      grunt.log.ok('No files found. Archive wouldn\'t be created ("doNotCreateEmptyArchive" is set to true)');
+      grunt.log.ok('No files found. Archive wouldn\'t be created ("doNotCreateEmptyArchive" option is set to true)');
       return;
     }
 

--- a/test/compress_test.js
+++ b/test/compress_test.js
@@ -205,7 +205,7 @@ exports.compress = {
   },
   zipCreateEmptyArchiveOptionNotExists: function(test) {
     test.equals(
-        fileExists(path.join('tmp', 'zip_must_be_created_1.zip')), true,
+        fileExists(path.join('tmp', 'zip_must_be_created_2.zip')), true,
         'Archive will be created because no option "createEmptyArchive" passed');
     test.done();
   }

--- a/test/compress_test.js
+++ b/test/compress_test.js
@@ -7,6 +7,18 @@ var fs = require('fs');
 var unzip = require('unzip');
 var tar = require('tar');
 
+function fileExists(filePath)
+{
+  try
+  {
+    return fs.statSync(filePath).isFile();
+  }
+  catch (err)
+  {
+    return false;
+  }
+}
+
 exports.compress = {
   zip: function(test) {
     test.expect(1);
@@ -181,5 +193,23 @@ exports.compress = {
           next();
         });
     }, test.done);
+  },
+  zipDoNotCreateEmptyArchiveOptionTrue: function(test) {
+    test.equals(
+        fileExists(path.join('tmp', 'compress_test_files_empty_must_not_be_created_because_option_set_to_true.zip')), false,
+        'Archive must be not created if option "doNotCreateEmptyArchive" is true');
+    test.done();
+  },
+  zipDoNotCreateEmptyArchiveOptionFalse: function(test) {
+    test.equals(
+        fileExists(path.join('tmp', 'compress_test_files_empty_must_be_created_because_option_set_to_false.zip')), true,
+        'Archive must be created if option "doNotCreateEmptyArchive" is false');
+    test.done();
+  },
+  zipDoNotCreateEmptyArchiveOptionNotExists: function(test) {
+    test.equals(
+        fileExists(path.join('tmp', 'compress_test_files_empty_must_be_created_because_no_option_passed.zip')), true,
+        'Archive will be created because no option "doNotCreateEmptyArchive" passed');
+    test.done();
   }
 };

--- a/test/compress_test.js
+++ b/test/compress_test.js
@@ -193,19 +193,19 @@ exports.compress = {
   },
   zipDoNotCreateEmptyArchiveOptionTrue: function(test) {
     test.equals(
-        fileExists(path.join('tmp', 'compress_test_files_empty_must_not_be_created_because_option_set_to_true.zip')), false,
+        fileExists(path.join('tmp', 'zip_should_not_be_created_1.zip')), false,
         'Archive must be not created if option "doNotCreateEmptyArchive" is true');
     test.done();
   },
   zipDoNotCreateEmptyArchiveOptionFalse: function(test) {
     test.equals(
-        fileExists(path.join('tmp', 'compress_test_files_empty_must_be_created_because_option_set_to_false.zip')), true,
+        fileExists(path.join('tmp', 'zip_must_be_created_1.zip')), true,
         'Archive must be created if option "doNotCreateEmptyArchive" is false');
     test.done();
   },
   zipDoNotCreateEmptyArchiveOptionNotExists: function(test) {
     test.equals(
-        fileExists(path.join('tmp', 'compress_test_files_empty_must_be_created_because_no_option_passed.zip')), true,
+        fileExists(path.join('tmp', 'zip_must_be_created_2.zip')), true,
         'Archive will be created because no option "doNotCreateEmptyArchive" passed');
     test.done();
   }

--- a/test/compress_test.js
+++ b/test/compress_test.js
@@ -192,24 +192,6 @@ exports.compress = {
         });
     }, test.done);
   },
-  zipCreateEmptyArchiveOptionTrue: function(test) {
-    test.equals(
-        fileExists(path.join('tmp', 'zip_must_be_created_1.zip')), true,
-        'Archive must be created if option "createEmptyArchive" is true');
-    test.done();
-  },
-  zipCreateEmptyArchiveOptionFalse: function(test) {
-    test.equals(
-        fileExists(path.join('tmp', 'zip_should_not_be_created.zip')), false,
-        'Archive must not be created if option "createEmptyArchive" is false');
-    test.done();
-  },
-  zipCreateEmptyArchiveOptionNotExists: function(test) {
-    test.equals(
-        fileExists(path.join('tmp', 'zip_must_be_created_2.zip')), true,
-        'Archive will be created because no option "createEmptyArchive" passed');
-    test.done();
-  },
   brotli: function (test) {
     test.expect(3);
     grunt.util.async.forEachSeries([
@@ -261,5 +243,23 @@ exports.compress = {
           next();
         });
     }, test.done);
+  },
+  zipCreateEmptyArchiveOptionTrue: function(test) {
+      test.equals(
+          fileExists(path.join('tmp', 'zip_must_be_created_1.zip')), true,
+          'Archive must be created if option "createEmptyArchive" is true');
+      test.done();
+  },
+  zipCreateEmptyArchiveOptionFalse: function(test) {
+      test.equals(
+          fileExists(path.join('tmp', 'zip_should_not_be_created.zip')), false,
+          'Archive must not be created if option "createEmptyArchive" is false');
+      test.done();
+  },
+  zipCreateEmptyArchiveOptionNotExists: function(test) {
+      test.equals(
+          fileExists(path.join('tmp', 'zip_must_be_created_2.zip')), true,
+          'Archive will be created because no option "createEmptyArchive" passed');
+      test.done();
   }
 };

--- a/test/compress_test.js
+++ b/test/compress_test.js
@@ -191,22 +191,22 @@ exports.compress = {
         });
     }, test.done);
   },
-  zipDoNotCreateEmptyArchiveOptionTrue: function(test) {
-    test.equals(
-        fileExists(path.join('tmp', 'zip_should_not_be_created_1.zip')), false,
-        'Archive must be not created if option "doNotCreateEmptyArchive" is true');
-    test.done();
-  },
-  zipDoNotCreateEmptyArchiveOptionFalse: function(test) {
+  zipCreateEmptyArchiveOptionTrue: function(test) {
     test.equals(
         fileExists(path.join('tmp', 'zip_must_be_created_1.zip')), true,
-        'Archive must be created if option "doNotCreateEmptyArchive" is false');
+        'Archive must be created if option "createEmptyArchive" is true');
     test.done();
   },
-  zipDoNotCreateEmptyArchiveOptionNotExists: function(test) {
+  zipCreateEmptyArchiveOptionFalse: function(test) {
     test.equals(
-        fileExists(path.join('tmp', 'zip_must_be_created_2.zip')), true,
-        'Archive will be created because no option "doNotCreateEmptyArchive" passed');
+        fileExists(path.join('tmp', 'zip_should_not_be_created.zip')), false,
+        'Archive must not be created if option "createEmptyArchive" is false');
+    test.done();
+  },
+  zipCreateEmptyArchiveOptionNotExists: function(test) {
+    test.equals(
+        fileExists(path.join('tmp', 'zip_must_be_created_1.zip')), true,
+        'Archive will be created because no option "createEmptyArchive" passed');
     test.done();
   }
 };

--- a/test/compress_test.js
+++ b/test/compress_test.js
@@ -7,14 +7,11 @@ var fs = require('fs');
 var unzip = require('unzip');
 var tar = require('tar');
 
-function fileExists(filePath)
-{
-  try
-  {
+function fileExists(filePath) {
+  try {
     return fs.statSync(filePath).isFile();
   }
-  catch (err)
-  {
+  catch (err) {
     return false;
   }
 }

--- a/test/compress_test.js
+++ b/test/compress_test.js
@@ -8,15 +8,6 @@ var unzip = require('unzip');
 var tar = require('tar');
 var iltorb = require('iltorb');
 
-function fileExists(filePath) {
-  try {
-    return fs.statSync(filePath).isFile();
-  }
-  catch (err) {
-    return false;
-  }
-}
-
 exports.compress = {
   zip: function (test) {
     test.expect(1);
@@ -246,19 +237,19 @@ exports.compress = {
   },
   zipCreateEmptyArchiveOptionTrue: function(test) {
       test.equals(
-          fileExists(path.join('tmp', 'zip_must_be_created_1.zip')), true,
+          grunt.file.exists(path.join('tmp', 'zip_must_be_created_1.zip')), true,
           'Archive must be created if option "createEmptyArchive" is true');
       test.done();
   },
   zipCreateEmptyArchiveOptionFalse: function(test) {
       test.equals(
-          fileExists(path.join('tmp', 'zip_should_not_be_created.zip')), false,
+          grunt.file.exists(path.join('tmp', 'zip_should_not_be_created.zip')), false,
           'Archive must not be created if option "createEmptyArchive" is false');
       test.done();
   },
   zipCreateEmptyArchiveOptionNotExists: function(test) {
       test.equals(
-          fileExists(path.join('tmp', 'zip_must_be_created_2.zip')), true,
+          grunt.file.exists(path.join('tmp', 'zip_must_be_created_2.zip')), true,
           'Archive will be created because no option "createEmptyArchive" passed');
       test.done();
   }


### PR DESCRIPTION
Some days ago I created this issue: https://github.com/gruntjs/grunt-contrib-compress/issues/185

I realized, that `compress` task from `grunt-contrib-compress` npm module will create empty `zip` file if files, which are specified at `files` option are not exists.

I created this pull request. I added option, which will add this missing (as I think) feature.

I have 2 questions also: 
1) Do you think this name of option is good? Or should I rename it to some another name?
2) About tests. Do you think I created correct tests for the changes?

Please, correct my PR or add some comments so I can correct the code or PR.
