### PR TITLE
v1.4.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v1.4.0:
+  date: 2017-01-18
+  changes:
+    - Add support for `brotli`
 v1.3.0:
   date: 2016-05-24
   changes:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grunt-contrib-compress v1.3.0 [![Build Status: Linux](https://travis-ci.org/gruntjs/grunt-contrib-compress.svg?branch=master)](https://travis-ci.org/gruntjs/grunt-contrib-compress) [![Build Status: Windows](https://ci.appveyor.com/api/projects/status/tiwbi1smm1j8aa5j/branch/master?svg=true)](https://ci.appveyor.com/project/gruntjs/grunt-contrib-compress/branch/master)
+# grunt-contrib-compress v1.4.0 [![Build Status: Linux](https://travis-ci.org/gruntjs/grunt-contrib-compress.svg?branch=master)](https://travis-ci.org/gruntjs/grunt-contrib-compress) [![Build Status: Windows](https://ci.appveyor.com/api/projects/status/tiwbi1smm1j8aa5j/branch/master?svg=true)](https://ci.appveyor.com/project/gruntjs/grunt-contrib-compress/branch/master)
 
 > Compress files and folders
 
@@ -273,6 +273,7 @@ compress: {
 
 ## Release History
 
+ * 2017-01-18   v1.4.0   Add support for `brotli`
  * 2016-05-24   v1.3.0   Update to Archiver 1.0. Fix node 6 support.
  * 2016-03-24   v1.2.0   Dependency update.
  * 2016-03-08   v1.1.1   Fix verbose output.
@@ -315,4 +316,4 @@ compress: {
 
 Task submitted by [Chris Talkington](http://christalkington.com/)
 
-*This file was generated on Thu Oct 13 2016 15:15:37.*
+*This file was generated on Wed Jan 18 2017 10:11:32.*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-contrib-compress",
   "description": "Compress files and folders",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "Grunt Team",
     "url": "http://gruntjs.com/"


### PR DESCRIPTION
@XhmikosR @vladikoff This PR is to release v1.4.0 which contains the great work done by @weigo and others in https://github.com/gruntjs/grunt-contrib-compress/pull/187.

I've been using `brotli` compression in a project with success by using that commit hash in my package.json but we can release this for ease of use.

I've followed the instructions here: http://gruntjs.com/contributing#publishing-a-new-version including the CLA, but I can't create a tag or publish to npm so I'll need some help.

Thanks!