### PR TITLE
Make iltorb an optional dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,12 @@
   "dependencies": {
     "archiver": "^1.0.0",
     "chalk": "^1.1.1",
-    "iltorb": "^1.0.13",
     "lodash": "^4.7.0",
     "pretty-bytes": "^3.0.1",
     "stream-buffers": "^2.1.0"
+  },
+  "optionalDependencies": {
+    "iltorb": "^1.0.13"
   },
   "devDependencies": {
     "grunt": "^1.0.0",

--- a/tasks/compress.js
+++ b/tasks/compress.js
@@ -11,6 +11,13 @@
 module.exports = function(grunt) {
   var _ = require('lodash');
   var compress = require('./lib/compress')(grunt);
+  var iltorb;
+
+  try {
+    iltorb = require('iltorb');
+  } catch (er) {
+    iltorb = null;
+  }
 
   grunt.registerMultiTask('compress', 'Compress files.', function() {
     compress.options = this.options({
@@ -25,8 +32,13 @@ module.exports = function(grunt) {
 
     compress.options.mode = compress.options.mode || compress.autoDetectMode(compress.options.archive);
 
+    if (compress.options.mode.match('brotli') && !iltorb) {
+        grunt.fail.fatal('iltorb dependency wasn\'t found; in order to use brotli, ' +
+                          'make sure you have a supported C++ compiler available and run `npm install` again.');
+    }
+
     if (_.includes(['zip', 'tar', 'tgz', 'gzip', 'deflate', 'deflateRaw', 'brotli'], compress.options.mode) === false) {
-      grunt.fail.warn('Mode ' + String(compress.options.mode).cyan + ' not supported.');
+      grunt.fail.warn('Mode ' + String(compress.options.mode) + ' not supported.');
     }
 
     if (/gzip|brotli/.test(compress.options.mode) || compress.options.mode.slice(0, 7) === 'deflate') {

--- a/tasks/lib/compress.js
+++ b/tasks/lib/compress.js
@@ -16,7 +16,14 @@ var zlib = require('zlib');
 var archiver = require('archiver');
 var streamBuffers = require('stream-buffers');
 var _ = require('lodash');
-var iltorb = require('iltorb');
+
+var iltorb;
+
+try {
+  iltorb = require('iltorb');
+} catch (er) {
+  iltorb = null;
+}
 
 module.exports = function(grunt) {
 
@@ -104,7 +111,13 @@ module.exports = function(grunt) {
           initDestStream();
         }
 
-        var compressor = extension === 'br' ? algorithm.call(iltorb, exports.options.brotli) : algorithm.call(zlib, exports.options);
+        var compressor;
+
+        if (iltorb && extension === 'br') {
+          compressor = algorithm.call(iltorb, exports.options.brotli);
+        } else {
+          compressor = algorithm.call(zlib, exports.options);
+        }
 
         compressor.on('error', function(err) {
           grunt.log.error(err);


### PR DESCRIPTION
Some systems don't have the needed compiler available, so just fail if the user tries to use brotli.

Fixes #190.
