### PR TITLE
Updated iltorb to latest minor version for v1.*

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "stream-buffers": "^2.1.0"
   },
   "optionalDependencies": {
-    "iltorb": "^1.0.13"
+    "iltorb": "^1.3.10"
   },
   "devDependencies": {
     "grunt": "^1.0.0",


### PR DESCRIPTION
I've created this pull request because the current `iltorb` version has `deep-extend` v0.4 as a dependency which has a security vulnerability as was pointed out to us by github. This PR upgrades iltorb to version 1.3.10, resulting in a deep-merge version of 0.6, which is higher than the recommended version of 5.1.

See: https://hackerone.com/reports/311333