### PR TITLE
update tar to 4.4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "grunt-contrib-internal": "^1.1.0",
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-nodeunit": "^1.0.0",
-    "tar": "^2.2.1",
+    "tar": "^4.4.8",
     "unzip": "^0.1.5"
   },
   "keywords": [

--- a/test/compress_test.js
+++ b/test/compress_test.js
@@ -61,6 +61,7 @@ exports.compress = {
     fs.createReadStream(path.join('tmp', 'compress_test_files.tar')).pipe(parse);
     parse.on('entry', function (entry) {
       actual.push(entry.path);
+      entry.resume();
     });
     parse.on('end', function () {
       actual.sort();
@@ -83,6 +84,7 @@ exports.compress = {
       .pipe(parse);
     parse.on('entry', function (entry) {
       actual.push(entry.path);
+      entry.resume();
     });
     parse.on('end', function () {
       actual.sort();

--- a/test/compress_test.js
+++ b/test/compress_test.js
@@ -57,7 +57,7 @@ exports.compress = {
       'test.css', 'test.js'
     ];
     var actual = [];
-    var parse = tar.Parse();
+    var parse = new tar.Parse();
     fs.createReadStream(path.join('tmp', 'compress_test_files.tar')).pipe(parse);
     parse.on('entry', function (entry) {
       actual.push(entry.path);
@@ -77,7 +77,7 @@ exports.compress = {
       'test.css', 'test.js'
     ];
     var actual = [];
-    var parse = tar.Parse();
+    var parse = new tar.Parse();
     fs.createReadStream(path.join('tmp', 'compress_test_files.tgz'))
       .pipe(zlib.createGunzip())
       .pipe(parse);


### PR DESCRIPTION
Tar is vulnerable prior to 4.4.2.

 https://nodesecurity.io/advisories/803  