### PR TITLE
remove iltorb dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
     "pretty-bytes": "^4.0.2",
     "stream-buffers": "^2.1.0"
   },
-  "optionalDependencies": {
-    "iltorb": "^2.4.5"
-  },
   "devDependencies": {
     "grunt": "^1.0.0",
     "grunt-contrib-clean": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "stream-buffers": "^2.1.0"
   },
   "optionalDependencies": {
-    "iltorb": "^2.4.3"
+    "iltorb": "^2.4.5"
   },
   "devDependencies": {
     "grunt": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "stream-buffers": "^2.1.0"
   },
   "optionalDependencies": {
-    "iltorb": "^1.3.10"
+    "iltorb": "^2.4.3"
   },
   "devDependencies": {
     "grunt": "^1.0.0",

--- a/tasks/lib/compress.js
+++ b/tasks/lib/compress.js
@@ -17,14 +17,6 @@ var archiver = require('archiver');
 var streamBuffers = require('stream-buffers');
 var _ = require('lodash');
 
-var iltorb;
-
-try {
-  iltorb = require('iltorb');
-} catch (er) {
-  iltorb = null;
-}
-
 module.exports = function(grunt) {
 
   var exports = {
@@ -64,12 +56,12 @@ module.exports = function(grunt) {
 
   // 1 to 1 brotlify of files
   exports.brotli = function(files, done) {
-    exports.singleFile(files, iltorb.compressStream, 'br', done);
+    exports.singleFile(files, zlib.createBrotliCompress, 'br', done);
     grunt.log.ok('Compressed ' + chalk.cyan(files.length) + ' ' +
       grunt.util.pluralize(files.length, 'file/files.'));
   };
 
-  // 1 to 1 compression of files, expects a compatible zlib or iltorb/brotli method to be passed in, see above
+  // 1 to 1 compression of files, expects a compatible zlib method to be passed in, see above
   exports.singleFile = function(files, algorithm, extension, done) {
     grunt.util.async.forEachSeries(files, function(filePair, nextPair) {
       grunt.util.async.forEachSeries(filePair.src, function(src, nextFile) {
@@ -111,13 +103,7 @@ module.exports = function(grunt) {
           initDestStream();
         }
 
-        var compressor;
-
-        if (iltorb && extension === 'br') {
-          compressor = algorithm.call(iltorb, exports.options.brotli);
-        } else {
-          compressor = algorithm.call(zlib, exports.options);
-        }
+        var compressor = algorithm.call(zlib, exports.options);
 
         compressor.on('error', function(err) {
           grunt.log.error(err);


### PR DESCRIPTION
Hello!

Beginning with Nodejs 11 we can use brotli compression from zlib.

I suggest to remove iltorb dependency.

To do this, we need to change the options of brotli.
https://nodejs.org/api/zlib.html#zlib_class_brotlioptions

Before:
```
options: {
	brotli: {
		mode: 0,
		quality: 11,
		lgwin: 22,
		lgblock: 0
	}
}
```

After:
```
options: {
	mode: 'brotli',
	chunkSize: 32 * 1024,
	params: {
		[zlib.constants.BROTLI_PARAM_MODE]: 0,
		[zlib.constants.BROTLI_PARAM_QUALITY]: 9,
		[zlib.constants.BROTLI_PARAM_LGWIN]: 22,
		[zlib.constants.BROTLI_PARAM_LGBLOCK]: 0
	}
}
```
And require zlib:
`const zlib = require('zlib');`